### PR TITLE
Fixed Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.tar.gz
-psc-package
+psc-package/psc-package
+psc-package/psc-package.exe
+!.gitkeep

--- a/psc-package/psc-package
+++ b/psc-package/psc-package
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-echo "This is a stub that will be replaced on install"


### PR DESCRIPTION
I'm sorry. I forgot the necessary action.
The previous commit has overwritten the Windows binary with a stub file.